### PR TITLE
Add health score predictor

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,33 +3,33 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Patient Satisfaction Calculator</title>
+    <title>Health Score Predictor</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>Patient Satisfaction with Access to Healthcare</h1>
-    <p>Use the sliders to rate satisfaction (1 = very dissatisfied, 5 = very satisfied).</p>
+    <h1>Health Score Predictor</h1>
+    <p>Adjust the sliders to rate each factor (1 = very poor, 100 = excellent).</p>
 
     <div class="slider-container">
-        <label for="availability">Availability: <span id="availability-value">3</span></label>
-        <input type="range" id="availability" min="1" max="5" step="1" value="3">
+        <label for="nutrition">Nutrition: <span id="nutrition-value">50</span></label>
+        <input type="range" id="nutrition" min="1" max="100" step="1" value="50">
 
-        <label for="accessibility">Accessibility: <span id="accessibility-value">3</span></label>
-        <input type="range" id="accessibility" min="1" max="5" step="1" value="3">
+        <label for="exercise">Exercise: <span id="exercise-value">50</span></label>
+        <input type="range" id="exercise" min="1" max="100" step="1" value="50">
 
-        <label for="accommodation">Accommodation: <span id="accommodation-value">3</span></label>
-        <input type="range" id="accommodation" min="1" max="5" step="1" value="3">
+        <label for="sleep">Sleep: <span id="sleep-value">50</span></label>
+        <input type="range" id="sleep" min="1" max="100" step="1" value="50">
 
-        <label for="affordability">Affordability: <span id="affordability-value">3</span></label>
-        <input type="range" id="affordability" min="1" max="5" step="1" value="3">
+        <label for="stress">Stress Management: <span id="stress-value">50</span></label>
+        <input type="range" id="stress" min="1" max="100" step="1" value="50">
 
-        <label for="acceptability">Acceptability: <span id="acceptability-value">3</span></label>
-        <input type="range" id="acceptability" min="1" max="5" step="1" value="3">
+        <label for="wellbeing">Mental Well-being: <span id="wellbeing-value">50</span></label>
+        <input type="range" id="wellbeing" min="1" max="100" step="1" value="50">
     </div>
 
     <div class="chart-container">
-        <canvas id="satisfactionChart"></canvas>
-        <p>Overall Satisfaction: <span id="overall-score">3.0</span></p>
+        <canvas id="healthChart"></canvas>
+        <p>Predicted Health Score: <span id="overall-score">50</span></p>
     </div>
 
     <button id="reset">Reset to Default</button>

--- a/script.js
+++ b/script.js
@@ -1,31 +1,31 @@
 // Get slider elements and their value displays
 const sliders = {
-    availability: document.getElementById('availability'),
-    accessibility: document.getElementById('accessibility'),
-    accommodation: document.getElementById('accommodation'),
-    affordability: document.getElementById('affordability'),
-    acceptability: document.getElementById('acceptability')
+    nutrition: document.getElementById('nutrition'),
+    exercise: document.getElementById('exercise'),
+    sleep: document.getElementById('sleep'),
+    stress: document.getElementById('stress'),
+    wellbeing: document.getElementById('wellbeing')
 };
 
 const valueDisplays = {
-    availability: document.getElementById('availability-value'),
-    accessibility: document.getElementById('accessibility-value'),
-    accommodation: document.getElementById('accommodation-value'),
-    affordability: document.getElementById('affordability-value'),
-    acceptability: document.getElementById('acceptability-value')
+    nutrition: document.getElementById('nutrition-value'),
+    exercise: document.getElementById('exercise-value'),
+    sleep: document.getElementById('sleep-value'),
+    stress: document.getElementById('stress-value'),
+    wellbeing: document.getElementById('wellbeing-value')
 };
 
 // Get chart canvas and overall score display
-const ctx = document.getElementById('satisfactionChart').getContext('2d');
+const ctx = document.getElementById('healthChart').getContext('2d');
 const overallScoreDisplay = document.getElementById('overall-score');
 
 // Initialize gauge chart
-let satisfactionChart = new Chart(ctx, {
+let healthChart = new Chart(ctx, {
     type: 'doughnut',
     data: {
-        labels: ['Satisfaction', 'Remaining'],
+        labels: ['Health Score', 'Remaining'],
         datasets: [{
-            data: [3, 2],
+            data: [50, 50],
             backgroundColor: ['#4caf50', '#e0e0e0'],
             borderWidth: 0
         }]
@@ -43,18 +43,18 @@ let satisfactionChart = new Chart(ctx, {
     }
 });
 
-// Calculate overall satisfaction
-function calculateSatisfaction() {
+// Calculate overall health score
+function calculateHealthScore() {
     const total = Object.values(sliders).reduce((sum, slider) => sum + parseInt(slider.value), 0);
-    return (total / 5).toFixed(1);
+    return Math.round(total / 5);
 }
 
 // Update chart and score display
 function updateChart() {
-    const score = calculateSatisfaction();
+    const score = calculateHealthScore();
     overallScoreDisplay.textContent = score;
-    satisfactionChart.data.datasets[0].data = [score, 5 - score];
-    satisfactionChart.update();
+    healthChart.data.datasets[0].data = [score, 100 - score];
+    healthChart.update();
 }
 
 // Update displays and chart on slider change
@@ -68,8 +68,8 @@ Object.values(sliders).forEach(slider => {
 // Reset sliders to default
 document.getElementById('reset').addEventListener('click', () => {
     Object.values(sliders).forEach(slider => {
-        slider.value = 3;
-        valueDisplays[slider.id].textContent = 3;
+        slider.value = 50;
+        valueDisplays[slider.id].textContent = 50;
     });
     updateChart();
 });


### PR DESCRIPTION
## Summary
- repurpose the demo page to predict a health score
- compute averages from new sliders for nutrition, exercise, sleep, stress, and mental well-being
- show score using a Chart.js gauge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405d352e1c832c86330288c776e6c8